### PR TITLE
Bump patch versions for gem and npm package

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Tamada-Arino/simple-inline-text-annotation.git"
+    "url": "https://github.com/pubannotation/simple_inline_annotation_format"
   },
   "author": "",
   "license": "MIT",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-inline-text-annotation",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A JavaScript library for inline text annotation with denotations and entity types",
   "main": "src/index.mjs",
   "scripts": {

--- a/ruby/CHANGELOG.md
+++ b/ruby/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+## [1.1.1] - 2025-05-22
+
+- Changed `homepage` in gemspec and package.json to the organization repository (https://github.com/pubannotation/simple_inline_annotation_format)
+
+
+## [1.1.0] - 2025-05-07
+
+- Added support for relation annotation in `parse` and `generate` methods
+
+
 ## [0.1.0] - 2025-04-01
 
 - Initial release

--- a/ruby/lib/simple_inline_text_annotation/version.rb
+++ b/ruby/lib/simple_inline_text_annotation/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class SimpleInlineTextAnnotation
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/ruby/simple_inline_text_annotation.gemspec
+++ b/ruby/simple_inline_text_annotation.gemspec
@@ -11,12 +11,12 @@ Gem::Specification.new do |s|
   s.summary = "A Ruby gem for inline text annotation with denotations and entity types."
   s.description = "This gem provides inline text annotation functionality, extracted from PubAnnotation, " \
                   "with support for denotations, entity types, and nested spans."
-  s.homepage = "https://github.com/Tamada-Arino/simple-inline-text-annotation"
+  s.homepage = "https://github.com/pubannotation/simple_inline_annotation_format"
   s.license = "MIT"
   s.required_ruby_version = ">= 3.1.0"
 
   s.metadata["homepage_uri"] = s.homepage
-  s.metadata["changelog_uri"] = "https://github.com/Tamada-Arino/simple-inline-text-annotation/blob/master/CHANGELOG.md"
+  s.metadata["changelog_uri"] = "https://github.com/pubannotation/simple_inline_annotation_format/blob/master/ruby/CHANGELOG.md"
   s.metadata["rubygems_uri"] = "https://rubygems.org/gems/simple_inline_text_annotation"
 
   gemspec = File.basename(__FILE__)


### PR DESCRIPTION
## 概要

リポジトリの移動にあたり、npmパッケージとgemのリポジトリのURLを変更しました。
ruby/CHANGELOG.mdに現在までのバージョンの変更について記載しました。