### PR TITLE
Raise RelationWithoutDenotationError when parse and found relation without denotations

### DIFF
--- a/ruby/lib/simple_inline_text_annotation.rb
+++ b/ruby/lib/simple_inline_text_annotation.rb
@@ -25,6 +25,7 @@ class SimpleInlineTextAnnotation
     @denotations = denotations
     @relations = relations
     @entity_type_collection = entity_type_collection
+    check_denotations_and_relations
   end
 
   def self.parse(source)
@@ -69,5 +70,20 @@ class SimpleInlineTextAnnotation
     return nil unless @entity_type_collection.any?
 
     { "entity types" => @entity_type_collection.to_config }
+  end
+
+  def check_denotations_and_relations
+    @relations.each do |relation|
+      unless referable_to?(relation, @denotations)
+        raise SimpleInlineTextAnnotation::RelationWithoutDenotationError,
+              "Relation #{relation.inspect} refers to missing denotation."
+      end
+    end
+  end
+
+  def referable_to?(relation, denotations)
+    denotation_ids = denotations.map(&:id)
+
+    denotation_ids.include?(relation["subj"]) && denotation_ids.include?(relation["obj"])
   end
 end

--- a/ruby/lib/simple_inline_text_annotation/parser.rb
+++ b/ruby/lib/simple_inline_text_annotation/parser.rb
@@ -2,6 +2,7 @@
 
 require_relative "entity_type_collection"
 require_relative "denotation"
+require_relative "relation_without_denotation_error"
 
 class SimpleInlineTextAnnotation
   class Parser
@@ -20,6 +21,7 @@ class SimpleInlineTextAnnotation
       full_text = source_without_references
 
       process_annotations(full_text)
+      check_denotations_and_relations
 
       SimpleInlineTextAnnotation.new(
         full_text,
@@ -90,6 +92,20 @@ class SimpleInlineTextAnnotation
       obj = get_obj_for(label)
       @denotations << Denotation.new(begin_pos, end_pos, obj, subj)
       @relations << { "pred" => pred, "subj" => subj, "obj" => obj2 }
+    end
+
+    def check_denotations_and_relations
+      @relations.each do |relation|
+        unless referable_to?(relation, @denotations)
+          raise SimpleInlineTextAnnotation::RelationWithoutDenotationError,
+                "Relation #{relation.inspect} refers to missing denotation."
+        end
+      end
+    end
+
+    def referable_to?(relation, denotations)
+      denotation_ids = denotations.map { it["id"] }
+      denotation_ids.include?(relation["subj"]) && denotation_ids.include?(relation["obj"])
     end
   end
 end

--- a/ruby/lib/simple_inline_text_annotation/parser.rb
+++ b/ruby/lib/simple_inline_text_annotation/parser.rb
@@ -13,17 +13,15 @@ class SimpleInlineTextAnnotation
     def initialize(source)
       @source = source.dup.freeze
       @entity_type_collection = EntityTypeCollection.new(source)
+      @denotations = []
+      @relations = []
+      @full_text = source_without_references
+      process_annotations(@full_text)
+      check_denotations_and_relations
     end
 
     def parse
-      @denotations = []
-      @relations = []
-      full_text = source_without_references
-
-      process_annotations(full_text)
-      check_denotations_and_relations
-
-      SimpleInlineTextAnnotation.new full_text,
+      SimpleInlineTextAnnotation.new @full_text,
                                      @denotations,
                                      @relations,
                                      @entity_type_collection

--- a/ruby/lib/simple_inline_text_annotation/parser.rb
+++ b/ruby/lib/simple_inline_text_annotation/parser.rb
@@ -13,15 +13,17 @@ class SimpleInlineTextAnnotation
     def initialize(source)
       @source = source.dup.freeze
       @entity_type_collection = EntityTypeCollection.new(source)
-      @denotations = []
-      @relations = []
-      @full_text = source_without_references
-      process_annotations(@full_text)
-      check_denotations_and_relations
     end
 
     def parse
-      SimpleInlineTextAnnotation.new @full_text,
+      @denotations = []
+      @relations = []
+      full_text = source_without_references
+
+      process_annotations(full_text)
+      check_denotations_and_relations
+
+      SimpleInlineTextAnnotation.new full_text,
                                      @denotations,
                                      @relations,
                                      @entity_type_collection

--- a/ruby/lib/simple_inline_text_annotation/parser.rb
+++ b/ruby/lib/simple_inline_text_annotation/parser.rb
@@ -23,12 +23,10 @@ class SimpleInlineTextAnnotation
       process_annotations(full_text)
       check_denotations_and_relations
 
-      SimpleInlineTextAnnotation.new(
-        full_text,
-        @denotations,
-        @relations,
-        @entity_type_collection
-      )
+      SimpleInlineTextAnnotation.new full_text,
+                                     @denotations,
+                                     @relations,
+                                     @entity_type_collection
     end
 
     private

--- a/ruby/lib/simple_inline_text_annotation/parser.rb
+++ b/ruby/lib/simple_inline_text_annotation/parser.rb
@@ -58,6 +58,7 @@ class SimpleInlineTextAnnotation
       return match.end(0) unless process_annotation(match[2], begin_pos, end_pos)
 
       full_text[match.begin(0)...match.end(0)] = target_text
+
       end_pos
     end
 
@@ -103,6 +104,7 @@ class SimpleInlineTextAnnotation
 
     def referable_to?(relation, denotations)
       denotation_ids = denotations.map { it["id"] }
+
       denotation_ids.include?(relation["subj"]) && denotation_ids.include?(relation["obj"])
     end
   end

--- a/ruby/lib/simple_inline_text_annotation/parser.rb
+++ b/ruby/lib/simple_inline_text_annotation/parser.rb
@@ -21,7 +21,6 @@ class SimpleInlineTextAnnotation
       full_text = source_without_references
 
       process_annotations(full_text)
-      check_denotations_and_relations
 
       SimpleInlineTextAnnotation.new full_text,
                                      @denotations,
@@ -91,21 +90,6 @@ class SimpleInlineTextAnnotation
       obj = get_obj_for(label)
       @denotations << Denotation.new(begin_pos, end_pos, obj, subj)
       @relations << { "pred" => pred, "subj" => subj, "obj" => obj2 }
-    end
-
-    def check_denotations_and_relations
-      @relations.each do |relation|
-        unless referable_to?(relation, @denotations)
-          raise SimpleInlineTextAnnotation::RelationWithoutDenotationError,
-                "Relation #{relation.inspect} refers to missing denotation."
-        end
-      end
-    end
-
-    def referable_to?(relation, denotations)
-      denotation_ids = denotations.map(&:id)
-
-      denotation_ids.include?(relation["subj"]) && denotation_ids.include?(relation["obj"])
     end
   end
 end

--- a/ruby/lib/simple_inline_text_annotation/parser.rb
+++ b/ruby/lib/simple_inline_text_annotation/parser.rb
@@ -103,7 +103,7 @@ class SimpleInlineTextAnnotation
     end
 
     def referable_to?(relation, denotations)
-      denotation_ids = denotations.map { it["id"] }
+      denotation_ids = denotations.map(&:id)
 
       denotation_ids.include?(relation["subj"]) && denotation_ids.include?(relation["obj"])
     end

--- a/ruby/lib/simple_inline_text_annotation/relation_without_denotation_error.rb
+++ b/ruby/lib/simple_inline_text_annotation/relation_without_denotation_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class SimpleInlineTextAnnotation
+  class RelationWithoutDenotationError < StandardError; end
+end

--- a/ruby/spec/simple_inline_text_annotation/parser_spec.rb
+++ b/ruby/spec/simple_inline_text_annotation/parser_spec.rb
@@ -432,5 +432,13 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         expect(result[:denotations]).to eq(expected_format[:denotations])
       end
     end
+
+    context "when source relations are fragmented" do
+      let(:source) { "[Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia." }
+
+      it "raise RelationWithoutDenotationError" do
+        expect { subject }.to raise_error(SimpleInlineTextAnnotation::RelationWithoutDenotationError)
+      end
+    end
   end
 end

--- a/ruby/spec/simple_inline_text_annotation/parser_spec.rb
+++ b/ruby/spec/simple_inline_text_annotation/parser_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
     context "when reference definitions do not have a blank line above" do
       let(:source) do
         <<~MD2
-          [Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
+          [Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
           [Person]: https://example.com/Person
         MD2
       end
@@ -86,7 +86,8 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.\n[Person]: https://example.com/Person",
           "denotations" => [
-            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" }
+            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+            { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
           ],
           "relations" => [
             { "pred" => "member_of", "subj" => "T1", "obj" => "T2" }
@@ -102,7 +103,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
     context "when reference definitions have a blank line above" do
       let(:source) do
         <<~MD2
-          [Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
+          [Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
 
           [Person]: https://example.com/Person
         MD2
@@ -111,7 +112,8 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "https://example.com/Person" }
+            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "https://example.com/Person" },
+            { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
           ],
           "relations" => [
             { "pred" => "member_of", "subj" => "T1", "obj" => "T2" }
@@ -166,7 +168,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
       context "when text is not enclosed with quotation" do
         let(:source) do
           <<~MD2
-            [Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
+            [Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
 
             [Person]: https://example.com/Person text
           MD2
@@ -175,7 +177,8 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
           {
             "text" => "Elon Musk is a member of the PayPal Mafia.\n\n[Person]: https://example.com/Person text",
             "denotations" => [
-              { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" }
+              { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+              { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
             ],
             "relations" => [
               { "pred" => "member_of", "subj" => "T1", "obj" => "T2" }
@@ -192,7 +195,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
     context "when text is written below the reference definition" do
       let(:source) do
         <<~MD2
-          [Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
+          [Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
 
           [Person]: https://example.com/Person
           hello
@@ -202,7 +205,8 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.\n\nhello",
           "denotations" => [
-            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "https://example.com/Person" }
+            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "https://example.com/Person" },
+            { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
           ],
           "relations" => [
             { "pred" => "member_of", "subj" => "T1", "obj" => "T2" }
@@ -223,7 +227,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
     context "when reference id is duplicated" do
       let(:source) do
         <<~MD2
-          [Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
+          [Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
 
           [Person]: https://example.com/Person
           [Person]: https://example.com/Organization
@@ -233,7 +237,8 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "https://example.com/Person" }
+            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "https://example.com/Person" },
+            { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
           ],
           "relations" => [
             { "pred" => "member_of", "subj" => "T1", "obj" => "T2" }
@@ -254,7 +259,7 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
     context "when reference label and id is same" do
       let(:source) do
         <<~MD2
-          [Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
+          [Elon Musk][T1, Person, member_of, T2] is a member of the [PayPal Mafia][T2, Organization].
 
           [Person]: Person
         MD2
@@ -263,7 +268,8 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" }
+            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+            { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
           ],
           "relations" => [
             { "pred" => "member_of", "subj" => "T1", "obj" => "T2" }
@@ -282,14 +288,15 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
           [Elon Musk][T1, Person, member_of, T2] is a member of the PayPal Mafia.
 
 
-          Elon Musk is a member of the PayPal Mafia.
+          Elon Musk is a member of the [PayPal Mafia][T2, Organization].
         MD2
       end
       let(:expected_format) do
         {
           "text" => "Elon Musk is a member of the PayPal Mafia.\n\nElon Musk is a member of the PayPal Mafia.",
           "denotations" => [
-            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" }
+            { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+            { "id" => "T2", "span" => { "begin" => 74, "end" => 86 }, "obj" => "Organization" }
           ],
           "relations" => [
             { "pred" => "member_of", "subj" => "T1", "obj" => "T2" }
@@ -357,13 +364,14 @@ RSpec.describe SimpleInlineTextAnnotation::Parser, type: :model do
     context "when there are three consecutive brackets" do
       context "and the second bracket has a valid number of elements" do
         let(:source) do
-          "[Elon Musk][T1, Person, member_of, T2][Fuga] is a member of the PayPal Mafia."
+          "[Elon Musk][T1, Person, member_of, T2][Fuga] is a member of the [PayPal Mafia][T2, Organization]."
         end
         let(:expected_format) do
           {
             "text" => "Elon Musk[Fuga] is a member of the PayPal Mafia.",
             "denotations" => [
-              { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" }
+              { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+              { "id" => "T2", "span" => { "begin" => 35, "end" => 47 }, "obj" => "Organization" }
             ],
             "relations" => [
               { "pred" => "member_of", "subj" => "T1", "obj" => "T2" }


### PR DESCRIPTION
## 概要

SimpleInlineTextAnnotation.parse での処理時にデノテーションを伴わないリレーションを見つけた時に、`RelationWithoutDenotationError` を上げるようにしました。

またこれに伴い、既存のテストを修正しました。