### PR TITLE
Bump ruby version to 3.4.4 in gem release

### DIFF
--- a/.github/workflows/gem_release.yml
+++ b/.github/workflows/gem_release.yml
@@ -7,7 +7,7 @@ jobs:
   run-tests:
     uses: ./.github/workflows/ruby_test.yml
     with:
-      ruby-version: '3.4.2'
+      ruby-version: '3.4.4'
 
   release:
     name: Release to RubyGems


### PR DESCRIPTION
## 概要

Release Gem ワークフローで失敗しました。

原因は gem_release.yml で ruby-version を 3.4.2 から 3.4.4 に上げ忘れたためです。

このPRで 3.4.4 に上げます。